### PR TITLE
Upgrade Spring Boot to version 3.5.6 (#37)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.4</version>
+		<version>3.5.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -58,8 +58,8 @@
 		</dependency>
 		<dependency>
 			<!-- Use MySQL Connector-J -->
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 		</dependency>
         <dependency>
             <groupId>com.h2database</groupId>
@@ -72,18 +72,6 @@
 			<artifactId>lombok</artifactId>
 			<version>1.18.20</version>
 			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<!-- Automated JSON API documentation for API's built with Spring -->
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger2</artifactId>
-			<version>2.9.2</version>
-		</dependency>
-		<dependency>
-			<!-- Generate beautiful documentation from a Swagger-compliant API. -->
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger-ui</artifactId>
-			<version>2.10.0</version>
 		</dependency>
 		<dependency>
 			<!-- JSON Web Token Support -->


### PR DESCRIPTION
This pull request updates the project to use Spring Boot 3.5.6, as requested in Issue #37. 

Changes include:

Updated Spring Boot parent version from 2.5.4 -> 3.5.6

Updated MySQL driver dependency from mysql-connector-java to mysql-connector-j for Boot 3 compatibility

Removed incompatible Springfox Swagger dependencies